### PR TITLE
Feat: added code formatting config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+.code
+globals.d.ts
+*.png
+*.jpeg
+*.mp4
+*.mp3
+*.vtt
+*.ico
+*.toml
+
+**/partials/markup
+**/partials/import
+**/dist
+
+.gitignore
+.gitkeep
+.prettierignore

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,33 @@
+{
+  "useTabs": false,
+  "singleQuote": true,
+  "trailingComm": "all",
+  "singleAttributePerLine": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "experimentalTernaries": true,
+  "plugins": ["@ianvs/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "^clsx$",
+    "^react$",
+    "^next",
+    "",
+    "~.*icons",
+    "",
+    ".css$",
+    "",
+    "^node:",
+    "<THIRD_PARTY_MODULES>",
+    "",
+    ".webp?$",
+    ".mp4?$",
+    "",
+    "^[$]",
+    "^[../]",
+    "^(?!.*[.](png|webp|mp4)$)[./].*$"
+  ],
+  "importOrderParserPlugins": ["jsx", "typescript", "decorators"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrderCaseInsensitive": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "useTabs": false,
   "singleQuote": true,
-  "trailingComm": "all",
+  "trailingComma": "all",
   "singleAttributePerLine": false,
   "printWidth": 80,
   "tabWidth": 2,

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "useTabs": false,
   "singleQuote": true,
   "trailingComm": "all",
-  "singleAttributePerLine": true,
+  "singleAttributePerLine": false,
   "printWidth": 80,
   "tabWidth": 2,
   "experimentalTernaries": true,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
     "postcss": "^8.4.24",
+    "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "0.2.5",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier src --write --log-level warn"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.0",
@@ -49,7 +50,7 @@
     "eslint-plugin-react-refresh": "^0.3.4",
     "postcss": "^8.4.24",
     "prettier": "^3.3.3",
-    "prettier-plugin-tailwindcss": "0.2.5",
+    "prettier-plugin-tailwindcss": "^0.6.5",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "youtube-chat": "^2.2.0"
   },
   "devDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
     "@types/node": "^20.8.0",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ dependencies:
 devDependencies:
   '@ianvs/prettier-plugin-sort-imports':
     specifier: ^4.3.1
-    version: 4.3.1(prettier@3.3.2)
+    version: 4.3.1(prettier@3.3.3)
   '@types/node':
     specifier: ^20.8.0
     version: 20.14.8
@@ -115,9 +115,12 @@ devDependencies:
   postcss:
     specifier: ^8.4.24
     version: 8.4.38
+  prettier:
+    specifier: ^3.3.3
+    version: 3.3.3
   prettier-plugin-tailwindcss:
     specifier: 0.2.5
-    version: 0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.2)
+    version: 0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.3)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -654,7 +657,7 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@ianvs/prettier-plugin-sort-imports@4.3.1(prettier@3.3.2):
+  /@ianvs/prettier-plugin-sort-imports@4.3.1(prettier@3.3.3):
     resolution: {integrity: sha512-ZHwbyjkANZOjaBm3ZosADD2OUYGFzQGxfy67HmGZU94mHqe7g1LCMA7YYKB1Cq+UTPCBqlAYapY0KXAjKEw8Sg==}
     peerDependencies:
       '@vue/compiler-sfc': 2.7.x || 3.x
@@ -668,7 +671,7 @@ packages:
       '@babel/parser': 7.24.7
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
-      prettier: 3.3.2
+      prettier: 3.3.3
       semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
@@ -2661,7 +2664,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-tailwindcss@0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.2):
+  /prettier-plugin-tailwindcss@0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.3):
     resolution: {integrity: sha512-vZ/iKieyCx0WTxHbkf5E1rBlv/ybFk8WTT4hL5W2jlVxum2Zbe0jMUpuQdDrpa4z2vnPiJ5KIWCqL/kd16fKYg==}
     engines: {node: '>=12.17.0'}
     peerDependencies:
@@ -2713,12 +2716,12 @@ packages:
       prettier-plugin-twig-melody:
         optional: true
     dependencies:
-      '@ianvs/prettier-plugin-sort-imports': 4.3.1(prettier@3.3.2)
-      prettier: 3.3.2
+      '@ianvs/prettier-plugin-sort-imports': 4.3.1(prettier@3.3.3)
+      prettier: 3.3.3
     dev: true
 
-  /prettier@3.3.2:
-    resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
+  /prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ dependencies:
     version: 2.2.0
 
 devDependencies:
+  '@ianvs/prettier-plugin-sort-imports':
+    specifier: ^4.3.1
+    version: 4.3.1(prettier@3.3.2)
   '@types/node':
     specifier: ^20.8.0
     version: 20.14.8
@@ -114,7 +117,7 @@ devDependencies:
     version: 8.4.38
   prettier-plugin-tailwindcss:
     specifier: 0.2.5
-    version: 0.2.5(prettier@3.3.2)
+    version: 0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.2)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -649,6 +652,26 @@ packages:
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+    dev: true
+
+  /@ianvs/prettier-plugin-sort-imports@4.3.1(prettier@3.3.2):
+    resolution: {integrity: sha512-ZHwbyjkANZOjaBm3ZosADD2OUYGFzQGxfy67HmGZU94mHqe7g1LCMA7YYKB1Cq+UTPCBqlAYapY0KXAjKEw8Sg==}
+    peerDependencies:
+      '@vue/compiler-sfc': 2.7.x || 3.x
+      prettier: 2 || 3
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+      prettier: 3.3.2
+      semver: 7.6.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -2638,7 +2661,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-tailwindcss@0.2.5(prettier@3.3.2):
+  /prettier-plugin-tailwindcss@0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.2):
     resolution: {integrity: sha512-vZ/iKieyCx0WTxHbkf5E1rBlv/ybFk8WTT4hL5W2jlVxum2Zbe0jMUpuQdDrpa4z2vnPiJ5KIWCqL/kd16fKYg==}
     engines: {node: '>=12.17.0'}
     peerDependencies:
@@ -2690,6 +2713,7 @@ packages:
       prettier-plugin-twig-melody:
         optional: true
     dependencies:
+      '@ianvs/prettier-plugin-sort-imports': 4.3.1(prettier@3.3.2)
       prettier: 3.3.2
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ devDependencies:
     specifier: ^3.3.3
     version: 3.3.3
   prettier-plugin-tailwindcss:
-    specifier: 0.2.5
-    version: 0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.3)
+    specifier: ^0.6.5
+    version: 0.6.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.3)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -2664,38 +2664,36 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-tailwindcss@0.2.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.3):
-    resolution: {integrity: sha512-vZ/iKieyCx0WTxHbkf5E1rBlv/ybFk8WTT4hL5W2jlVxum2Zbe0jMUpuQdDrpa4z2vnPiJ5KIWCqL/kd16fKYg==}
-    engines: {node: '>=12.17.0'}
+  /prettier-plugin-tailwindcss@0.6.5(@ianvs/prettier-plugin-sort-imports@4.3.1)(prettier@3.3.3):
+    resolution: {integrity: sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==}
+    engines: {node: '>=14.21.3'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-php': '*'
       '@prettier/plugin-pug': '*'
       '@shopify/prettier-plugin-liquid': '*'
-      '@shufo/prettier-plugin-blade': '*'
       '@trivago/prettier-plugin-sort-imports': '*'
-      prettier: '>=2.2.0'
+      '@zackad/prettier-plugin-twig-melody': '*'
+      prettier: ^3.0
       prettier-plugin-astro: '*'
       prettier-plugin-css-order: '*'
       prettier-plugin-import-sort: '*'
       prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
       prettier-plugin-organize-attributes: '*'
       prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
       prettier-plugin-style-order: '*'
       prettier-plugin-svelte: '*'
-      prettier-plugin-twig-melody: '*'
     peerDependenciesMeta:
       '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-php':
         optional: true
       '@prettier/plugin-pug':
         optional: true
       '@shopify/prettier-plugin-liquid':
         optional: true
-      '@shufo/prettier-plugin-blade':
-        optional: true
       '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig-melody':
         optional: true
       prettier-plugin-astro:
         optional: true
@@ -2705,15 +2703,17 @@ packages:
         optional: true
       prettier-plugin-jsdoc:
         optional: true
+      prettier-plugin-marko:
+        optional: true
       prettier-plugin-organize-attributes:
         optional: true
       prettier-plugin-organize-imports:
         optional: true
+      prettier-plugin-sort-imports:
+        optional: true
       prettier-plugin-style-order:
         optional: true
       prettier-plugin-svelte:
-        optional: true
-      prettier-plugin-twig-melody:
         optional: true
     dependencies:
       '@ianvs/prettier-plugin-sort-imports': 4.3.1(prettier@3.3.3)


### PR DESCRIPTION
### Added prettier: 
- added config files to format the code.
### Added auto sort Imports:
- added a plugin to sort and group imports.
#
Added `format` command in `package.json`.

### Here's how the code will look after running:
```bash
pnpm run format
```
*This will format all the files in `/src`*
| Before | After |
|--------|-------|
| ![Before Image](https://github.com/user-attachments/assets/81a5e2d2-6878-4c83-a8b1-bcecd1a0448f) | ![After Image](https://github.com/user-attachments/assets/3435e372-5a26-4bcd-bd4e-482286167b30) |

