### PR TITLE
Update MIT License with correct year and owner name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2024 Samay Raina
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #22 

## Issue: License Template Missing Year and Owner Name

The MIT License template provided did not specify the current year or the full name of the copyright holder. According to the MIT License requirements, it should include:

- The current year when the software is being distributed (2024).
- The full name of the copyright holder (Samay Raina).

This information is crucial for clarity and compliance with the license terms. This pull request updates the template to reflect the correct details.
