### PR TITLE
fixing percentile circle on welcome page | adding border shadow

### DIFF
--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -239,7 +239,11 @@ const PercentileItem = ({ title, percentile, description, message }: PercentileI
   >
     <h3 className="text-2xl font-semibold text-neon-green mb-2">{title}</h3>
     <div className="flex items-center mb-4">
-      <div className="w-16 h-16 rounded-full bg-neon-green/20 flex items-center justify-center mr-4">
+      <div className="w-16 h-16 p-2 rounded-full bg-neon-green/20 flex items-center justify-center mr-4"  
+      style={{
+        border: '2px solid rgba(0, 255, 0, 0.5)',
+        boxShadow: '0 0 5px rgba(0, 255, 0, 0.5)'
+      }}>
         <span className="text-2xl font-bold text-neon-green">{percentile}%</span>
       </div>
       <p className="text-white">


### PR DESCRIPTION
fixing the percentile circle on welcome page for mobile devices and adding border shadow to same circle to improve visual.

| Before | After |
| ------------- | ------------- |
| ![Screenshot (13)](https://github.com/user-attachments/assets/59029f56-0707-4b94-bd45-f9aeca69deca) | ![Screenshot (12)](https://github.com/user-attachments/assets/ce7217ae-9d8f-4489-add8-de35373b841b) |