### PR TITLE
- sidebar logout button glitch

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -67,10 +67,12 @@ const Sidebar = () => {
     }
   };
 
-  const handleMouseLeave = () => {
+  const handleMouseLeave = (event: any) => {
     if (!isMobile) {
-      setIsHovered(false);
-      setIsCollapsed(true);
+      if(event.relatedTarget && event.relatedTarget != window && event.currentTarget != event.relatedTarget){
+        setIsHovered(false);
+        setIsCollapsed(true);
+      }
     }
   };
 


### PR DESCRIPTION
fix : #46 
The current behavior of Sidebar
  If the dropdown is not open: the Sidebar will open and close on the mouse enter and mouse leave events respectively as expected
  If the dropdown is open: mouse events will not have any effect. 