### PR TITLE
Double Logout Mobile UI

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -180,7 +180,7 @@ const Sidebar = () => {
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <NavContent />
+          {/* <NavContent /> */}
         </motion.div>
       </AnimatePresence>
     </>


### PR DESCRIPTION
In src/components/sidebar the < NavContent /> inside <AnimatePresence> at line-173 is present.
When we remove that < NavContent /> component it fixes the issue of showing the logout button at top.
After removing the component everything works fine we can logout and login without any error.


| Before | After |
| ------------- | ------------- |
| ![Screenshot (18)](https://github.com/user-attachments/assets/0991ea3d-2398-4f48-abcc-b009e571dc13) | ![Screenshot (17)](https://github.com/user-attachments/assets/7e6d6d7c-69e4-4b0a-bb62-a4b7601954cd) |
 
 This is the components I'm talking about : 
 
![Screenshot (20)](https://github.com/user-attachments/assets/7b6ea31f-0b6f-4645-8865-b6b05362b661)
