### PR TITLE
Fixing learn page header

### DIFF
--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -17,14 +17,14 @@ const Learn = () => {
           
           <header className="sticky top-0 z-20 bg-black/70 backdrop-filter backdrop-blur-lg px-6 py-4 flex items-center justify-between shadow-xl border-b border-neon-green/20">
             <h1 className="text-3xl font-extrabold flex items-center">
-              <FaChessKnight className="text-neon-green mr-3 text-4xl" />
+              <FaChessKnight className="text-neon-green mr-3 text-4xl opacity-0 md:opacity-100" />
               <span className="bg-clip-text text-transparent bg-gradient-to-r from-neon-green to-blue-500">
                 Chess Learn
               </span>
             </h1>
-            <div className="flex items-center bg-white/10 rounded-full px-3 py-1">
-              <span className="mr-2 text-sm font-medium">powered by</span>
-              <img src={ccl} alt="Chess.com" className="h-6" />
+            <div className="flex flex-col md:flex-row justify-center items-center bg-white/10 rounded-full px-5 py-2">
+              <span className="md:mr-2 text-sm font-medium">powered by</span>
+              <img src={ccl} alt="Chess.com" className="h-5 md:h-6" />
             </div>
           </header>
 


### PR DESCRIPTION
- Adding padding for **Powered by chess.com**
- Removing **Knight Logo forom Mobile Devices** because it was overflowing on top of menu-button

| Before | After |
| --- | --- |
| ![Screenshot (40)](https://github.com/user-attachments/assets/6fe403e3-121e-4d4c-b1ca-c3971ee72db9) | ![Screenshot (41)](https://github.com/user-attachments/assets/f6048506-2fbc-4e94-888d-88ccee0816fd) |

| Before | 
| --- |
| ![Screenshot (38)](https://github.com/user-attachments/assets/6f789d49-6b13-468e-8234-b553ff0014ee) |

| After |
| --- |
| ![Screenshot (39)](https://github.com/user-attachments/assets/b456bffb-8167-46e1-b0ad-0f99eaa85721) |