### PR TITLE
dynamic year in the footer of privacy policy page

### DIFF
--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export default function PrivacyPolicy() {
   return (
@@ -13,7 +13,9 @@ export default function PrivacyPolicy() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <h2 className="text-2xl font-semibold mb-4">1. Information We Collect</h2>
+                <h2 className="text-2xl font-semibold mb-4">
+                  1. Information We Collect
+                </h2>
                 <p className="mb-4">
                   We collect the following information when you use our service:
                 </p>
@@ -25,10 +27,10 @@ export default function PrivacyPolicy() {
                   <li>Your chess statistics from Chess.com</li>
                 </ul>
 
-                <h2 className="text-2xl font-semibold mb-4">2. How We Use Your Information</h2>
-                <p className="mb-4">
-                  We use your information to:
-                </p>
+                <h2 className="text-2xl font-semibold mb-4">
+                  2. How We Use Your Information
+                </h2>
+                <p className="mb-4">We use your information to:</p>
                 <ul className="list-disc list-inside ml-4 mb-4">
                   <li>Provide and improve our services</li>
                   <li>Verify your Chess.com account</li>
@@ -36,34 +38,59 @@ export default function PrivacyPolicy() {
                   <li>Generate community statistics</li>
                 </ul>
 
-                <h2 className="text-2xl font-semibold mb-4">3. Data Sharing and Disclosure</h2>
+                <h2 className="text-2xl font-semibold mb-4">
+                  3. Data Sharing and Disclosure
+                </h2>
                 <p className="mb-4">
-                  We do not sell your personal information. We may share anonymized, aggregated data for community statistics.
+                  We do not sell your personal information. We may share
+                  anonymized, aggregated data for community statistics.
                 </p>
 
-                <h2 className="text-2xl font-semibold mb-4">4. Data Security</h2>
+                <h2 className="text-2xl font-semibold mb-4">
+                  4. Data Security
+                </h2>
                 <p className="mb-4">
-                  We implement security measures to protect your personal information. However, no method of transmission over the Internet is 100% secure.
+                  We implement security measures to protect your personal
+                  information. However, no method of transmission over the
+                  Internet is 100% secure.
                 </p>
 
                 <h2 className="text-2xl font-semibold mb-4">5. Your Rights</h2>
                 <p className="mb-4">
-                  You have the right to access, correct, or delete your personal information. Contact us to exercise these rights.
+                  You have the right to access, correct, or delete your personal
+                  information. Contact us to exercise these rights.
                 </p>
 
-                <h2 className="text-2xl font-semibold mb-4">6. Changes to This Policy</h2>
+                <h2 className="text-2xl font-semibold mb-4">
+                  6. Changes to This Policy
+                </h2>
                 <p className="mb-4">
-                  We may update this privacy policy from time to time. We will notify you of any changes by posting the new policy on this page.
+                  We may update this privacy policy from time to time. We will
+                  notify you of any changes by posting the new policy on this
+                  page.
                 </p>
 
                 <h2 className="text-2xl font-semibold mb-4">7. Contact Us</h2>
                 <p className="mb-4">
-                  If you have any questions about this privacy policy, please contact us at singhrakshit003@gmail.com.
+                  If you have any questions about this privacy policy, please
+                  contact us at singhrakshit003@gmail.com.
                 </p>
 
-                <h2 className="text-2xl font-semibold mb-4">8. Google API Services User Data Policy</h2>
+                <h2 className="text-2xl font-semibold mb-4">
+                  8. Google API Services User Data Policy
+                </h2>
                 <p className="mb-4">
-                  BM Samay Raina's use and transfer of information received from Google APIs to any other app will adhere to the <a href="https://developers.google.com/terms/api-services-user-data-policy" target="_blank" rel="noopener noreferrer" className="text-neon-green hover:underline">Google API Services User Data Policy</a>, including the Limited Use requirements.
+                  BM Samay Raina's use and transfer of information received from
+                  Google APIs to any other app will adhere to the{' '}
+                  <a
+                    href="https://developers.google.com/terms/api-services-user-data-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-neon-green hover:underline"
+                  >
+                    Google API Services User Data Policy
+                  </a>
+                  , including the Limited Use requirements.
                 </p>
               </CardContent>
             </Card>
@@ -71,7 +98,9 @@ export default function PrivacyPolicy() {
         </section>
       </main>
       <footer className="flex flex-col gap-2 sm:flex-row py-6 w-full shrink-0 items-center px-4 md:px-6 border-t border-gray-700">
-        <p className="text-xs text-gray-500">© 2024 BM SamayRaina. All rights reserved.</p>
+        <p className="text-xs text-gray-500">
+          © {new Date().getFullYear()} BM SamayRaina. All rights reserved.
+        </p>
       </footer>
     </div>
   );


### PR DESCRIPTION
In privacy policy page in the footer section added dynamic year generation instead of hard coding the year. 
example : replaced "2024" with {new Date().getFullYear()} javascript function .
Year will be automatically updated instead of hard coding and pushing it again and again to production.