### PR TITLE
Decrease the number of focusable elements by making the icons in sidebar non focusable.

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -93,7 +93,7 @@ const Sidebar = () => {
           whileTap={{ scale: item.comingSoon ? 1 : 0.95 }}
           className="flex items-center gap-4"
         >
-          <item.icon className={`h-5 w-5 ${isCollapsed && !isHovered ? 'mr-0' : 'mr-3'}`} />
+          <item.icon className={`h-5 w-5 ${isCollapsed && !isHovered ? 'mr-0' : 'mr-3'}`} aria-hidden="true"/>
           {(!isCollapsed || isHovered) && <span className="text-sm whitespace-nowrap">{item.name}</span>}
         </motion.div>
         {(!isCollapsed || isHovered) && item.comingSoon && (


### PR DESCRIPTION
There are some icons in the sidebar which are keyboard focusable, and they don't serve any purpose when the enter key is pressed when they are focused.
![image](https://github.com/user-attachments/assets/4c1d4c2e-bbe7-4b1b-9abc-45243b724b1c)
